### PR TITLE
Remove second replicas declaration

### DIFF
--- a/charts/homechart/templates/statefulset_postgresql.yaml
+++ b/charts/homechart/templates/statefulset_postgresql.yaml
@@ -12,7 +12,6 @@ spec:
       app: homechart
       service: postgresql
   serviceName: postgresql
-  replicas: 1
   template:
     metadata:
       {{- with .Values.postgresql.statefulset.annotations }}


### PR DESCRIPTION
The helm chart does not apply as we have defined replicas twice. Removing one will allow for the helm chart to reconcile and apply